### PR TITLE
[3/n Dynamic Feature Support] Add a new configuration flag useDynamicFeature to support dynamic features related attributes

### DIFF
--- a/src/com/facebook/buck/android/AndroidApkBuildable.java
+++ b/src/com/facebook/buck/android/AndroidApkBuildable.java
@@ -78,7 +78,8 @@ public class AndroidApkBuildable extends AndroidBinaryBuildable {
       apkModules,
       moduleResourceApkPaths,
       bundleConfigFilePath,
-      binaryType);
+      binaryType,
+      false);
   }
 
 

--- a/src/com/facebook/buck/android/AndroidBinaryBuildable.java
+++ b/src/com/facebook/buck/android/AndroidBinaryBuildable.java
@@ -107,6 +107,7 @@ abstract class AndroidBinaryBuildable implements AddsToRuleKey {
   protected final ProjectFilesystem filesystem;
   protected final BuildTarget buildTarget;
   protected final AndroidSdkLocation androidSdkLocation;
+  protected final boolean useDynamicFeature;
 
   AndroidBinaryBuildable(
       BuildTarget buildTarget,
@@ -127,7 +128,8 @@ abstract class AndroidBinaryBuildable implements AddsToRuleKey {
       ImmutableSortedSet<APKModule> apkModules,
       ImmutableMap<APKModule, SourcePath> moduleResourceApkPaths,
       Optional<SourcePath> bundleConfigFilePath,
-      BinaryType binaryType) {
+      BinaryType binaryType,
+      boolean useDynamicFeature) {
     this.filesystem = filesystem;
     this.buildTarget = buildTarget;
     this.androidSdkLocation = androidSdkLocation;
@@ -147,6 +149,7 @@ abstract class AndroidBinaryBuildable implements AddsToRuleKey {
     this.resourceFilesInfo = resourceFilesInfo;
     this.bundleConfigFilePath = bundleConfigFilePath;
     this.binaryType = binaryType;
+    this.useDynamicFeature = useDynamicFeature;
   }
 
   @SuppressWarnings("PMD.PrematureDeclaration")

--- a/src/com/facebook/buck/android/AndroidBundle.java
+++ b/src/com/facebook/buck/android/AndroidBundle.java
@@ -78,7 +78,7 @@ import java.util.stream.Stream;
  * )
  * </pre>
  *
- * Configuration for dynamic feature (enable use_split_dex and application_module_configs flags) :
+ * Configuration for dynamic feature (enable use_split_dex, use_dynamic_feature and application_module_configs flags) :
  * <pre>
  * android_bundle(
  *   name = 'messenger',
@@ -87,6 +87,7 @@ import java.util.stream.Stream;
  *     '//src/com/facebook/messenger:messenger_library',
  *   ],
  *   use_split_dex = True,
+ *   use_dynamic_feature = True,
  *   application_module_configs = {
  *     "feature1":['//feature1:module_root'],
  *   },
@@ -159,7 +160,8 @@ public class AndroidBundle extends AbstractBuildRule
       ResourceFilesInfo resourceFilesInfo,
       ImmutableSortedSet<APKModule> apkModules,
       Optional<ExopackageInfo> exopackageInfo,
-      Optional<SourcePath> bundleConfigFilePath) {
+      Optional<SourcePath> bundleConfigFilePath,
+      boolean useDynamicFeature) {
     super(buildTarget, projectFilesystem);
     Preconditions.checkArgument(params.getExtraDeps().get().isEmpty());
     this.ruleFinder = ruleFinder;
@@ -222,7 +224,8 @@ public class AndroidBundle extends AbstractBuildRule
             apkModules,
             enhancementResult.getModuleResourceApkPaths(),
             bundleConfigFilePath,
-            AAB);
+            AAB,
+            useDynamicFeature);
     this.optimizer =
         new AndroidBundleOptimizer(
             getBuildTarget(),

--- a/src/com/facebook/buck/android/AndroidBundleBuildable.java
+++ b/src/com/facebook/buck/android/AndroidBundleBuildable.java
@@ -60,7 +60,8 @@ public class AndroidBundleBuildable extends AndroidBinaryBuildable {
     ImmutableSortedSet<APKModule> apkModules,
     ImmutableMap<APKModule, SourcePath> moduleResourceApkPaths,
     Optional<SourcePath> bundleConfigFilePath,
-    BinaryType binaryType) {
+    BinaryType binaryType,
+    boolean useDynamicFeature) {
     super(
       buildTarget,
       filesystem,
@@ -80,7 +81,8 @@ public class AndroidBundleBuildable extends AndroidBinaryBuildable {
       apkModules,
       moduleResourceApkPaths,
       bundleConfigFilePath,
-      binaryType);
+      binaryType,
+      useDynamicFeature);
   }
 
   @Override

--- a/src/com/facebook/buck/android/AndroidBundleFactory.java
+++ b/src/com/facebook/buck/android/AndroidBundleFactory.java
@@ -135,6 +135,7 @@ public class AndroidBundleFactory {
         filesInfo.getResourceFilesInfo(),
         ImmutableSortedSet.copyOf(result.getAPKModuleGraph().getAPKModules()),
         filesInfo.getExopackageInfo(),
-        args.getBundleConfigFile());
+        args.getBundleConfigFile(),
+        args.getUseDynamicFeature());
   }
 }

--- a/src/com/facebook/buck/android/AndroidGraphEnhancerArgs.java
+++ b/src/com/facebook/buck/android/AndroidGraphEnhancerArgs.java
@@ -204,6 +204,11 @@ public interface AndroidGraphEnhancerArgs
   }
 
   @Value.Default
+  default boolean getUseDynamicFeature() {
+    return false;
+  }
+
+  @Value.Default
   default ImmutableSet<String> getExtraFilteredResources() {
     return ImmutableSet.of();
   }


### PR DESCRIPTION
Defined a new configuration flag useDynamicFeature to support backward compatibility of AndroidBundle and AndroidBinary rule. Later this flag is used to include any specific changes related to dynamic features