### PR TITLE
[4/n Dynamic Feature Support] Define new configuration application_modules_with_manifest to decouple the manifest behavior from the resources

### DIFF
--- a/src/com/facebook/buck/android/AndroidAppModularityDescription.java
+++ b/src/com/facebook/buck/android/AndroidAppModularityDescription.java
@@ -55,6 +55,7 @@ public class AndroidAppModularityDescription
             args.getApplicationModuleDependencies(),
             APKModuleGraph.extractTargetsFromQueries(args.getApplicationModuleBlacklist()),
             ImmutableSet.of(),
+            ImmutableSet.of(),
             context.getTargetGraph(),
             buildTarget);
 

--- a/src/com/facebook/buck/android/AndroidBinaryGraphEnhancerFactory.java
+++ b/src/com/facebook/buck/android/AndroidBinaryGraphEnhancerFactory.java
@@ -117,6 +117,7 @@ public class AndroidBinaryGraphEnhancerFactory {
               args.getApplicationModuleDependencies(),
               APKModuleGraph.extractTargetsFromQueries(args.getApplicationModuleBlacklist()),
               args.getApplicationModulesWithResources(),
+              args.getUseDynamicFeature()? args.getApplicationModulesWithManifest(): args.getApplicationModulesWithResources(),
               targetGraph,
               buildTarget);
     }

--- a/src/com/facebook/buck/android/AndroidBundle.java
+++ b/src/com/facebook/buck/android/AndroidBundle.java
@@ -79,6 +79,7 @@ import java.util.stream.Stream;
  * </pre>
  *
  * Configuration for dynamic feature (enable use_split_dex, use_dynamic_feature and application_module_configs flags) :
+ * <pre>A new configuration application_modules_with_manifest is defined to decouple the manifest behaviour from the resources. This approach is aligned with dynamic features heuristics where base manifest has complete information of the feature manifest</pre>
  * <pre>
  * android_bundle(
  *   name = 'messenger',
@@ -91,6 +92,9 @@ import java.util.stream.Stream;
  *   application_module_configs = {
  *     "feature1":['//feature1:module_root'],
  *   },
+ *   application_modules_with_manifest = [
+ *     "feature1",
+ *   ]
  * )
  * </pre>
  */

--- a/src/com/facebook/buck/android/AndroidGraphEnhancerArgs.java
+++ b/src/com/facebook/buck/android/AndroidGraphEnhancerArgs.java
@@ -101,6 +101,11 @@ public interface AndroidGraphEnhancerArgs
     return ImmutableSet.of();
   }
 
+  @Value.Default
+  default Set<String> getApplicationModulesWithManifest() {
+    return ImmutableSet.of();
+  }
+
   Optional<ImmutableMap<String, ImmutableList<String>>> getApplicationModuleDependencies();
 
   @Value.Default

--- a/src/com/facebook/buck/android/AndroidInstrumentationApkDescription.java
+++ b/src/com/facebook/buck/android/AndroidInstrumentationApkDescription.java
@@ -123,7 +123,7 @@ public class AndroidInstrumentationApkDescription
         .map(BuildRule::getBuildTarget)
         .forEach(buildTargetsToExclude::add);
 
-    APKModule rootAPKModule = APKModule.of(APKModuleGraph.ROOT_APKMODULE_NAME, true);
+    APKModule rootAPKModule = APKModule.of(APKModuleGraph.ROOT_APKMODULE_NAME, true, true);
     AndroidPackageableCollection.ResourceDetails resourceDetails =
         apkUnderTest.getAndroidPackageableCollection().getResourceDetails().get(rootAPKModule);
     ImmutableSet<BuildTarget> resourcesToExclude =

--- a/src/com/facebook/buck/android/AndroidManifestFactory.java
+++ b/src/com/facebook/buck/android/AndroidManifestFactory.java
@@ -42,7 +42,7 @@ public class AndroidManifestFactory {
         projectFilesystem,
         resolver,
         skeleton,
-        APKModule.of(APKModuleGraph.ROOT_APKMODULE_NAME, true),
+        APKModule.of(APKModuleGraph.ROOT_APKMODULE_NAME, true, true),
         manifestFiles);
   }
 }

--- a/src/com/facebook/buck/android/apkmodule/APKModule.java
+++ b/src/com/facebook/buck/android/apkmodule/APKModule.java
@@ -24,8 +24,8 @@ import org.immutables.value.Value;
 @BuckStyleValue
 public abstract class APKModule implements Comparable<APKModule>, AddsToRuleKey {
 
-  public static APKModule of(String name, boolean hasResources) {
-    return ImmutableAPKModule.of(name, hasResources);
+  public static APKModule of(String name, boolean hasResources, boolean hasManifest) {
+    return ImmutableAPKModule.of(name, hasResources, hasManifest);
   }
 
   @AddToRuleKey
@@ -33,6 +33,9 @@ public abstract class APKModule implements Comparable<APKModule>, AddsToRuleKey 
 
   @AddToRuleKey
   public abstract boolean hasResources();
+
+  @AddToRuleKey
+  public abstract boolean hasManifest();
 
   @Value.Derived
   public boolean isRootModule() {

--- a/src/com/facebook/buck/android/packageable/AndroidPackageableCollector.java
+++ b/src/com/facebook/buck/android/packageable/AndroidPackageableCollector.java
@@ -315,7 +315,7 @@ public class AndroidPackageableCollector {
       return this;
     }
     collectionBuilder.putAndroidManifestPieces(
-        apkModuleGraph.findResourceModuleForTarget(owner), manifest);
+        apkModuleGraph.findManifestModuleForTarget(owner), manifest);
     return this;
   }
 

--- a/test/com/facebook/buck/android/GenerateManifestStepTest.java
+++ b/test/com/facebook/buck/android/GenerateManifestStepTest.java
@@ -75,7 +75,7 @@ public class GenerateManifestStepTest {
         new GenerateManifestStep(
             filesystem,
             skeletonPath,
-            APKModule.of(APKModuleGraph.ROOT_APKMODULE_NAME, true),
+            APKModule.of(APKModuleGraph.ROOT_APKMODULE_NAME, true, true),
             libraryManifestFiles,
             outputPath,
             mergeReportPath);
@@ -119,7 +119,7 @@ public class GenerateManifestStepTest {
         new GenerateManifestStep(
             filesystem,
             skeletonPath,
-            APKModule.of("MODULE_NAME", false),
+            APKModule.of("MODULE_NAME", false, false),
             libraryManifestFiles,
             outputPath,
             mergeReportPath);

--- a/test/com/facebook/buck/android/PreDexedFilesSorterTest.java
+++ b/test/com/facebook/buck/android/PreDexedFilesSorterTest.java
@@ -62,7 +62,7 @@ public class PreDexedFilesSorterTest {
             TargetGraph.EMPTY,
             BuildTargetFactory.newInstance("//fakeTarget:yes"),
             Optional.empty());
-    extraModule = APKModule.of("extra", false);
+    extraModule = APKModule.of("extra", false, false);
   }
 
   @Test

--- a/test/com/facebook/buck/android/SplitZipStepTest.java
+++ b/test/com/facebook/buck/android/SplitZipStepTest.java
@@ -75,7 +75,7 @@ public class SplitZipStepTest {
       ImmutableSet<APKModule> requires = ImmutableSet.of();
       SplitZipStep.writeMetaList(
           writer,
-          APKModule.of(SplitZipStep.SECONDARY_DEX_ID, false),
+          APKModule.of(SplitZipStep.SECONDARY_DEX_ID, false, false),
           requires,
           ImmutableList.of(outJar),
           DexStore.JAR);
@@ -112,9 +112,9 @@ public class SplitZipStepTest {
 
     StringWriter stringWriter = new StringWriter();
     try (BufferedWriter writer = new BufferedWriter(stringWriter)) {
-      ImmutableSet<APKModule> requires = ImmutableSet.of(APKModule.of("dependency", false));
+      ImmutableSet<APKModule> requires = ImmutableSet.of(APKModule.of("dependency", false, false));
       SplitZipStep.writeMetaList(
-          writer, APKModule.of("module", false), requires, ImmutableList.of(outJar), DexStore.JAR);
+          writer, APKModule.of("module", false, false), requires, ImmutableList.of(outJar), DexStore.JAR);
     }
     List<String> lines = CharStreams.readLines(new StringReader(stringWriter.toString()));
     assertEquals(3, lines.size());

--- a/test/com/facebook/buck/android/apkmodule/APKModuleTest.java
+++ b/test/com/facebook/buck/android/apkmodule/APKModuleTest.java
@@ -363,6 +363,7 @@ public class APKModuleTest {
             Optional.of(appModuleDependencies.build()),
             Optional.empty(),
             ImmutableSet.of(),
+            ImmutableSet.of(),
             graph,
             androidBinaryTarget);
 
@@ -502,6 +503,7 @@ public class APKModuleTest {
             Optional.of(seedConfigMap.build()),
             Optional.of(appModuleDependencies.build()),
             Optional.empty(),
+            ImmutableSet.of(),
             ImmutableSet.of(),
             graph,
             androidBinaryTarget);
@@ -653,6 +655,7 @@ public class APKModuleTest {
             Optional.of(seedConfigMap.build()),
             Optional.of(appModuleDependencies.build()),
             Optional.empty(),
+            ImmutableSet.of(),
             ImmutableSet.of(),
             graph,
             androidBinaryTarget);
@@ -809,6 +812,7 @@ public class APKModuleTest {
             Optional.of(seedConfigMap.build()),
             Optional.of(appModuleDependencies.build()),
             Optional.empty(),
+            ImmutableSet.of(),
             ImmutableSet.of(),
             graph,
             androidBinaryTarget);

--- a/test/com/facebook/buck/android/packageable/AndroidPackageableCollectorTest.java
+++ b/test/com/facebook/buck/android/packageable/AndroidPackageableCollectorTest.java
@@ -316,7 +316,7 @@ public class AndroidPackageableCollectorTest {
             .map(BuildRule::getBuildTarget)
             .collect(ImmutableList.toImmutableList());
 
-    APKModule rootModule = APKModule.of(APKModuleGraph.ROOT_APKMODULE_NAME, true);
+    APKModule rootModule = APKModule.of(APKModuleGraph.ROOT_APKMODULE_NAME, true, true);
 
     assertEquals(
         "Android resources should be topologically sorted.",
@@ -401,7 +401,7 @@ public class AndroidPackageableCollectorTest {
     AndroidPackageableCollection.ResourceDetails resourceDetails =
         androidPackageableCollection
             .getResourceDetails()
-            .get(APKModule.of(APKModuleGraph.ROOT_APKMODULE_NAME, true));
+            .get(APKModule.of(APKModuleGraph.ROOT_APKMODULE_NAME, true, true));
     assertThat(
         resourceDetails.getResourceDirectories(), Matchers.contains(resAPath, resPath, resBPath));
   }


### PR DESCRIPTION
- Defined new configuration application_modules_with_manifest is defined to decouple the manifest behavior from the resources. This approach is aligned with dynamic features heuristics where the base manifest has complete information of the feature manifest.
- Added manifest tags in BUCK file: manifest_skeleton, module_manifest_skeleton, and application_modules_with_manifest
where AndroidManifestMerger tool will first merge all application_modules_with_manifest into module_manifest_skeleton, which is later merged into manifest_skeleton