### PR TITLE
[5/n Dynamic Feature Support] Enable buck to support dynamic features with native libraries

### DIFF
--- a/src/com/facebook/buck/android/AndroidBinaryBuildable.java
+++ b/src/com/facebook/buck/android/AndroidBinaryBuildable.java
@@ -289,7 +289,8 @@ abstract class AndroidBinaryBuildable implements AddsToRuleKey {
           assetDirectoriesBuilderForThisModule);
     }
 
-    boolean shouldPackageAssetLibraries = packageAssetLibraries || !module.isRootModule();
+    // Do not package native libraries as assets for dynamic feature modules. To keep the earlier implementation intact added check for useDynamicFeature.
+    boolean shouldPackageAssetLibraries = !useDynamicFeature && (packageAssetLibraries || !module.isRootModule());
     if (!ExopackageMode.enabledForNativeLibraries(exopackageModes)
         && nativeFilesInfo.nativeLibsDirs.isPresent()
         && nativeFilesInfo.nativeLibsDirs.get().containsKey(module)) {


### PR DESCRIPTION
Enable buck to support dynamic features with native libraries in buck. This change prevents buck from packaging native code in dynamic modules into lib.xzs files and therefore ensure that result App Bundle format is exactly the same as if it was done by gradle.

_Resulted App Bundle overview (before changes in buck)_:
<img width="1643" alt="Screenshot 2021-02-17 at 11 06 39 AM" src="https://user-images.githubusercontent.com/39046660/108161277-b4b35880-7110-11eb-8422-d7599cbb5df4.png">
- All feature modules contain assets with compressed `libs.xzs` file irrespective of the state if the feature has any native library or not
- Native libraries are copied for all possible APKModuleGraphs in the feature module. That's why you can see assets within `initialInstall` module has 4 sub-directories with `libs.xzs` copied across

_Resulted App Bundle overview (**after changes in buck**)_:
<img width="1647" alt="Screenshot 2021-02-17 at 11 23 29 AM" src="https://user-images.githubusercontent.com/39046660/108162195-9c443d80-7112-11eb-914e-ab1ef99f96c8.png">

Tested feature by including custom buck pex file in [PlayFeatureDelivery](https://github.com/uKetki/PlayFeatureDelivery/tree/test_dynamic_features_support) sample.

